### PR TITLE
Add Tween Utility

### DIFF
--- a/Core/Enumerations/TweenState.cs
+++ b/Core/Enumerations/TweenState.cs
@@ -1,0 +1,23 @@
+﻿namespace LeagueSharp.SDK.Core.Enumerations
+{
+    /// <summary>
+    ///     State of a Tween
+    /// </summary>
+    public enum TweenState
+    {
+        /// <summary>
+        ///     The tween is running
+        /// </summary>
+        Running,
+
+        /// <summary>
+        ///     The tween is paused
+        /// </summary>
+        Paused,
+
+        /// <summary>
+        ///     The tween has stopped
+        /// </summary>
+        Stopped
+    }
+}

--- a/Core/Utils/Tween/LerpFuncs.cs
+++ b/Core/Utils/Tween/LerpFuncs.cs
@@ -1,0 +1,111 @@
+﻿namespace LeagueSharp.SDK.Core.Utils.Tween
+{
+    using SharpDX;
+
+    using Color = System.Drawing.Color;
+
+    /// <summary>
+    ///     A "library" of commonly used lerp functions
+    /// </summary>
+    public class LerpFuncs
+    {
+        #region Public Methods and Operators
+
+        public static byte LerpByte(byte start, byte end, float progress)
+        {
+            return (byte)(start + (end - start) * progress);
+        }
+
+        public static char LerpChar(char start, char end, float progress)
+        {
+            return (char)(start + (end - start) * progress);
+        }
+
+        public static Color LerpColor(Color start, Color end, float progress)
+        {
+            return Color.FromArgb(
+                LerpByte(start.A, end.A, progress),
+                LerpByte(start.R, end.R, progress),
+                LerpByte(start.G, end.G, progress),
+                LerpByte(start.B, end.B, progress));
+        }
+
+        public static SharpDX.Color LerpColor(SharpDX.Color start, SharpDX.Color end, float progress)
+        {
+            return new SharpDX.Color(
+                LerpByte(start.A, end.A, progress),
+                LerpByte(start.R, end.R, progress),
+                LerpByte(start.G, end.G, progress),
+                LerpByte(start.B, end.B, progress));
+        }
+
+        public static double LerpDouble(double start, double end, float progress)
+        {
+            return start + (end - start) * progress;
+        }
+
+        public static float LerpFloat(float start, float end, float progress)
+        {
+            return start + (end - start) * progress;
+        }
+
+        public static int LerpInt(int start, int end, float progress)
+        {
+            return (int)(start + (end - start) * progress);
+        }
+
+        public static long LerpLong(long start, long end, float progress)
+        {
+            return (long)(start + (end - start) * progress);
+        }
+
+        public static sbyte LerpSByte(sbyte start, sbyte end, float progress)
+        {
+            return (sbyte)(start + (end - start) * progress);
+        }
+
+        public static short LerpShort(short start, short end, float progress)
+        {
+            return (short)(start + (end - start) * progress);
+        }
+
+        public static uint LerpUInt(uint start, uint end, float progress)
+        {
+            return (uint)(start + (end - start) * progress);
+        }
+
+        public static ulong LerpULong(ulong start, ulong end, float progress)
+        {
+            return (ulong)(start + (end - start) * progress);
+        }
+
+        public static ushort LerpUShort(ushort start, ushort end, float progress)
+        {
+            return (ushort)(start + (end - start) * progress);
+        }
+
+        public static Vector2 LerpVector2(Vector2 start, Vector2 end, float progress)
+        {
+            return new Vector2(LerpFloat(start.X, end.X, progress), LerpFloat(start.Y, end.Y, progress));
+        }
+
+        public static Vector3 LerpVector3(Vector3 start, Vector3 end, float progress)
+        {
+            return new Vector3(
+                LerpFloat(start.X, end.X, progress),
+                LerpFloat(start.Y, end.Y, progress),
+                LerpFloat(start.Z, end.Z, progress));
+        }
+
+        public static Vector4 LerpVector4(Vector4 start, Vector4 end, float progress)
+        {
+            return new Vector4(
+                LerpFloat(start.X, end.X, progress),
+                LerpFloat(start.Y, end.Y, progress),
+                LerpFloat(start.Z, end.Z, progress),
+                LerpFloat(start.W, end.W, progress));
+        }
+
+        #endregion
+    }
+}

--- a/Core/Utils/Tween/ScaleFuncs.cs
+++ b/Core/Utils/Tween/ScaleFuncs.cs
@@ -1,0 +1,133 @@
+﻿namespace LeagueSharp.SDK.Core.Utils.Tween
+{
+    using System;
+
+    /// <summary>
+    ///     A "library" of commonly used scale functions
+    /// </summary>
+    public class ScaleFuncs
+    {
+        #region Constants
+
+        private const float HalfPi = Pi / 2f;
+
+        private const float Pi = (float)Math.PI;
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        public static float CubicIn(float progress)
+        {
+            return EaseInPower(progress, 2);
+        }
+
+        public static float CubicInOut(float progress)
+        {
+            return EaseInOutPower(progress, 2);
+        }
+
+        public static float CubicOut(float progress)
+        {
+            return EaseOutPower(progress, 2);
+        }
+
+        public static float Linear(float progress)
+        {
+            return progress;
+        }
+
+        public static float QuadraticIn(float progress)
+        {
+            return EaseInPower(progress, 2);
+        }
+
+        public static float QuadraticInOut(float progress)
+        {
+            return EaseInOutPower(progress, 2);
+        }
+
+        public static float QuadraticOut(float progress)
+        {
+            return EaseOutPower(progress, 2);
+        }
+
+        public static float QuarticIn(float progress)
+        {
+            return EaseInPower(progress, 2);
+        }
+
+        public static float QuarticInOut(float progress)
+        {
+            return EaseInOutPower(progress, 2);
+        }
+
+        public static float QuarticOut(float progress)
+        {
+            return EaseOutPower(progress, 2);
+        }
+
+        public static float QuinticIn(float progress)
+        {
+            return EaseInPower(progress, 2);
+        }
+
+        public static float QuinticInOut(float progress)
+        {
+            return EaseInOutPower(progress, 2);
+        }
+
+        public static float QuinticOut(float progress)
+        {
+            return EaseOutPower(progress, 2);
+        }
+
+        public static float SineIn(float progress)
+        {
+            return (float)Math.Sin(progress * HalfPi - HalfPi) + 1f;
+        }
+
+        public static float SineInOut(float progress)
+        {
+            return (float)(Math.Sin(progress * Pi - HalfPi) + 1f) / 2f;
+        }
+
+        public static float SineOut(float progress)
+        {
+            return (float)Math.Sin(progress * HalfPi);
+        }
+
+        #endregion
+
+        #region Methods
+
+        private static float EaseInOutPower(float progress, int power)
+        {
+            progress *= 2f;
+
+            if (progress >= 1f)
+            {
+                return (float)Math.Pow(progress, power) / 2f;
+            }
+
+            var sign = power % 2 == 0 ? -1 : 1;
+            return (float)(sign / 2f * (Math.Pow(progress - 2f, power) + sign * 2f));
+        }
+
+        private static float EaseInPower(float progress, int power)
+        {
+            // I've switched ease in's and ease out's sources to better match how objects
+            // should act upon tweening: going out slow to fast, and coming in fast to slow.
+            var sign = power % 2 == 0 ? -1 : 1;
+            return (float)(sign * (Math.Pow(progress - 1f, power) + sign));
+        }
+
+        private static float EaseOutPower(float progress, int power)
+        {
+            // See ease in.
+            return (float)Math.Pow(progress, power);
+        }
+
+        #endregion
+    }
+}

--- a/Core/Utils/Tween/Tween.cs
+++ b/Core/Utils/Tween/Tween.cs
@@ -1,0 +1,296 @@
+﻿namespace LeagueSharp.SDK.Core.Utils.Tween
+{
+    using System;
+    using System.Diagnostics;
+
+    using LeagueSharp.SDK.Core.Enumerations;
+
+    /// <summary>
+    ///     Tween Utility, smoothly interpolates between two values over time
+    /// </summary>
+    /// <typeparam name="T">Type to tween</typeparam>
+    public class Tween<T>
+    {
+        #region Fields
+
+        /// <summary>
+        ///     The function that gives a value between the defined starting and ending values
+        /// </summary>
+        private readonly LerpFunc<T> lerpFunc;
+
+        /// <summary>
+        ///     Used for timing how long the tween has been running, to update our elapsed time accurately
+        /// </summary>
+        private readonly Stopwatch stopwatch;
+
+        /// <summary>
+        ///     The last time that we updated the elapsed time
+        /// </summary>
+        private long lastUpdateTime;
+
+        /// <summary>
+        ///     The function that scales our progress (elapsed time/duration)
+        /// </summary>
+        private ScaleFunc scaleFunc;
+
+        #endregion
+
+        #region Constructors and Destructors
+
+        /// <summary>
+        ///     Creates a Tween object to handle tweening a given type
+        /// </summary>
+        /// <param name="lerp">The function that handles lerping the given type</param>
+        /// <param name="defaultValue">A value to set <code>Value</code> to as a default</param>
+        public Tween(LerpFunc<T> lerp, T defaultValue = default(T))
+        {
+            this.State = TweenState.Stopped;
+            this.Value = defaultValue;
+            this.lerpFunc = lerp;
+            this.stopwatch = new Stopwatch();
+        }
+
+        #endregion
+
+        #region Delegates
+
+        /// <summary>
+        ///     Delegate for the Started, Paused, Resumed, Stopped, Finished, and Updated events
+        /// </summary>
+        /// <param name="tween">The tween that called the delegate</param>
+        public delegate void ActionHandler(Tween<T> tween);
+
+        /// <summary>
+        ///     Standard linear interpolation function of a type, typically following <code>start + (end - start)*scale</code>
+        /// </summary>
+        /// <typeparam name="TLerp">The type to linear interpolate</typeparam>
+        /// <param name="start">The starting value</param>
+        /// <param name="end">The ending value</param>
+        /// <param name="scale">The percent between start and end (that can go past the range [0, 1])</param>
+        /// <returns>The type that is scale percent between the start and end values</returns>
+        public delegate TLerp LerpFunc<TLerp>(TLerp start, TLerp end, float scale);
+
+        /// <summary>
+        ///     Takes in the progress of the tween and returns the interpolation value that is fed into the lerp function
+        /// </summary>
+        /// <param name="progress">The progress of the tween in the range [0, 1]</param>
+        /// <returns>The value that is fed into the lerp function</returns>
+        public delegate float ScaleFunc(float progress);
+
+        #endregion
+
+        #region Public Events
+
+        /// <summary>
+        ///     Called when the respective action happens on a tween object
+        /// </summary>
+        public event ActionHandler Started , Paused , Resumed , Stopped , Finished , Updated;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        ///     The duration of the tween (in milliseconds)
+        /// </summary>
+        public float Duration { get; private set; }
+
+        /// <summary>
+        ///     The current time that has been elapsed (in milliseconds)
+        /// </summary>
+        public float ElapsedTime { get; private set; }
+
+        /// <summary>
+        ///     The ending value of the tween
+        /// </summary>
+        public T EndValue { get; private set; }
+
+        /// <summary>
+        ///     The starting value of the tween
+        /// </summary>
+        public T StartValue { get; private set; }
+
+        /// <summary>
+        ///     The current state of the tween
+        /// </summary>
+        public TweenState State { get; private set; }
+
+        /// <summary>
+        ///     The current value of the tween
+        /// </summary>
+        public T Value { get; private set; }
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        /// <summary>
+        ///     Pauses a running tween
+        /// </summary>
+        /// <param name="callEvent">Whether or not to call the Paused event</param>
+        public void Pause(bool callEvent = true)
+        {
+            if (this.State != TweenState.Running)
+            {
+                return;
+            }
+
+            this.stopwatch.Stop();
+            this.State = TweenState.Paused;
+
+            if (callEvent)
+            {
+                this.InvokeEvent(this.Paused);
+            }
+        }
+
+        /// <summary>
+        ///     Pauses a running tween
+        /// </summary>
+        /// <param name="callEvent">Whether or not to call the Resumed event</param>
+        public void Resume(bool callEvent = true)
+        {
+            if (this.State != TweenState.Paused)
+            {
+                return;
+            }
+
+            this.stopwatch.Start();
+            this.State = TweenState.Running;
+
+            if (callEvent)
+            {
+                this.InvokeEvent(this.Resumed);
+            }
+        }
+
+        /// <summary>
+        ///     Starts a tween
+        /// </summary>
+        /// <param name="start">The starting value</param>
+        /// <param name="end">The ending value</param>
+        /// <param name="duration">The time the tween will run for (in milliseconds)</param>
+        /// <param name="scale">The function used to scale elapsed time over the duration</param>
+        /// <param name="callEvent">Whether or not to call the Started event</param>
+        public void Start(T start, T end, float duration, ScaleFunc scale, bool callEvent = true)
+        {
+            if (duration <= 0)
+            {
+                throw new ArgumentException(@"duration must be greater than 0", "duration");
+            }
+            if (scale == null)
+            {
+                throw new ArgumentNullException("scale");
+            }
+            if (this.State != TweenState.Stopped)
+            {
+                throw new Exception("Tween must be stopped to start tweening");
+            }
+
+            this.ElapsedTime = 0f;
+            this.Duration = duration;
+            this.StartValue = start;
+            this.EndValue = end;
+            this.scaleFunc = scale;
+            this.State = TweenState.Running;
+
+            this.stopwatch.Start();
+
+            Game.OnUpdate += this.OnGameUpdate;
+
+            if (callEvent)
+            {
+                this.InvokeEvent(this.Started);
+            }
+
+            this.UpdateValue();
+        }
+
+        /// <summary>
+        ///     Stops a running/paused tween
+        /// </summary>
+        /// <param name="forceComplete">
+        ///     Whether or not to force the value and the elapsed time to be equal to their respective
+        ///     ending values
+        /// </param>
+        /// <param name="callEvent">Whether or not to call the Stopped event</param>
+        public void Stop(bool forceComplete = true, bool callEvent = true)
+        {
+            if (this.State == TweenState.Stopped)
+            {
+                return;
+            }
+
+            this.stopwatch.Stop();
+            Game.OnUpdate -= this.OnGameUpdate;
+            this.State = TweenState.Stopped;
+
+            if (forceComplete)
+            {
+                this.ElapsedTime = this.Duration;
+                this.UpdateValue();
+            }
+
+            if (callEvent)
+            {
+                this.InvokeEvent(this.Stopped);
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        ///     Updates the Elapsed Time whenever the game updates
+        /// </summary>
+        /// <param name="args">Game Update Arguments</param>
+        private void OnGameUpdate(EventArgs args)
+        {
+            if (this.State != TweenState.Running)
+            {
+                return;
+            }
+
+            this.ElapsedTime += this.stopwatch.ElapsedMilliseconds - this.lastUpdateTime;
+            this.lastUpdateTime = this.stopwatch.ElapsedMilliseconds;
+
+            if (this.ElapsedTime >= this.Duration)
+            {
+                this.Stop(true, false);
+                this.InvokeEvent(this.Updated);
+                this.InvokeEvent(this.Finished);
+            }
+            else
+            {
+                this.UpdateValue();
+                this.InvokeEvent(this.Updated);
+            }
+        }
+
+        /// <summary>
+        ///     Updates the Value by calling the lerp and scale functions with their proper arguments
+        /// </summary>
+        private void UpdateValue()
+        {
+            // Everything has a `this` before it o-o
+            this.Value = this.lerpFunc(this.StartValue, this.EndValue, this.scaleFunc(this.ElapsedTime / this.Duration));
+        }
+
+        #endregion
+
+        /// <summary>
+        ///     Invokes an event if it isn't null
+        /// </summary>
+        /// <param name="event">The event to invoke</param>
+        private void InvokeEvent(ActionHandler @event)
+        {
+            // Since ReSharper blindly assumes this is C# 6:
+            // ReSharper disable once UseNullPropagation
+            if (@event != null)
+            {
+                @event.Invoke(this);
+            }
+        }
+    }
+}

--- a/LeagueSharp.SDK.csproj
+++ b/LeagueSharp.SDK.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Core\Enumerations\TeleportStatus.cs" />
     <Compile Include="Core\Enumerations\TeleportType.cs" />
     <Compile Include="Core\Enumerations\TurretShotType.cs" />
+    <Compile Include="Core\Enumerations\TweenState.cs" />
     <Compile Include="Core\Enumerations\WindowsMessages.cs" />
     <Compile Include="Core\Events\Gapcloser.cs" />
     <Compile Include="Core\Events\Teleport.cs" />
@@ -151,6 +152,8 @@
     <Compile Include="Core\Signals\Signal.cs" />
     <Compile Include="Core\Signals\SignalManager.cs" />
     <Compile Include="Core\Utils\Jungle.cs" />
+    <Compile Include="Core\Utils\Tween\LerpFuncs.cs" />
+    <Compile Include="Core\Utils\Tween\ScaleFuncs.cs" />
     <Compile Include="Core\Utils\Spells.cs" />
     <Compile Include="Core\UI\Developer\Developer.cs" />
     <Compile Include="Core\Utils\AutoAttack.cs" />
@@ -171,6 +174,7 @@
     <Compile Include="Core\Math\Collision.cs" />
     <Compile Include="Core\Utils\Cursor.cs" />
     <Compile Include="Core\Utils\Storage.cs" />
+    <Compile Include="Core\Utils\Tween\Tween.cs" />
     <Compile Include="Core\Utils\WindowsKeys.cs" />
     <Compile Include="Core\Utils\Math.cs" />
     <Compile Include="Core\Math\Polygons\Arc.cs" />


### PR DESCRIPTION
Should allow for smoother animations (cough pop-up-out-of-nowhere menu & super-linear notifications cough). I got lazy and didn't make xml comments for any of the lerp nor scale funcs.

[What in the world is tweening?](https://en.wikipedia.org/wiki/Inbetweening)

[Awesome example of tweening](http://gizma.com/easing/)

CodeExample: https://gist.github.com/Everesty/645eb0e138df81c7fdee (comments everywhere :P)

![Example](http://puu.sh/ixYI0/06a023df5c.gif)

The image shows 2 things: a full in & out, and what happens if the tween needs to immediately stop (fast press & release).

_Also,_ if you decide to go full-on w/ tweens, consider making a class for SharpDX color extensions. One that does something along the lines of:

``` c#
/// <summary>
///     Returns a clone of the given color object where the alpha
///     is as described by the parameters
/// </summary>
/// <param name="color">The color to replicate w/ a different alpha</param>
/// <param name="alpha">The alpha to set the returned color to</param>
/// <param name="preserveBaseRatio">Instead of setting directly to the given alpha, it'll set to <code>alpha * (base.A / 255)</code></param>
public static Color Alpha(this Color color, byte alpha, bool preserveBaseRatio = false) {
    // Also, remember that SharpDX has (more than iirc) two color
    //  classes: Color & ColorBGRA, so this method would need to be
    //  replicated for both, if not more.
    if (preserveBaseRatio)
        alpha = (byte)(alpha * (color.A / 255f));

    // I don't know how I should go about the result; I don't really want
    //  to create a new object because of performance, but on the other
    //  side I can't think of a good way to clone the color object.
    // Btw it's RGBA for parameters on this object (same for ColorBGRA).
    return new Color(color.R, color.G, color.B, alpha);
}
```

Doing that will allow for the following (expessed w/ code :P)

``` c#
// From Core/UI/IMenu/Skins/Default/DefaultTheme.cs @ line 413 - 419
//  edited as if the extension existed
// Assume MenuSettings.AlphaTween is a byte (or float) tween
MenuSettings.ContainerLine.Draw(
    new[]
        {
            new Vector2(position.X + (width / 2f), position.Y),
            new Vector2(position.X + (width / 2f), position.Y + height)
        },
    MenuSettings.RootContainerColor.Alpha(MenuSettings.AlphaTween.Value, true));
// Skip over it? Right above this line

// If there is no extension, it'll be a lot uglier:
var color = MenuSettings.RootContainerColor;
color.A = (byte) (MenuSettings.AlphaTween.Value * (color.A / 255f));
// [draw w/ color instead of MenuSettings.RootContainerColor]
// Imagine doing that for _every tweened draw_ instead of just calling an extension method
```
